### PR TITLE
fix: usePayload on server side

### DIFF
--- a/packages/fastify-vite-vue/blueprint/entry/core.js
+++ b/packages/fastify-vite-vue/blueprint/entry/core.js
@@ -41,16 +41,21 @@ export function createBeforeEachHandler (resolvedRoutes) {
     const ctx = useIsomorphic({ params: to.params })
     const {
       hasPayload,
+      getPayload,
       hasData,
       component,
     } = getRouteMeta(to, routeMap, parsedRoutes)
     if (!component) {
       return false
     }
-    if (!!window[kStaticPayload] && hasPayload) {
+    if (getPayload || (!!window[kStaticPayload] && hasPayload)) {
       try {
-        const response = await window.fetch(usePayloadPath(to))
-        ctx.$payload = await response.json()
+        if (typeof getPayload === 'function') {
+          ctx.$payload = await getPayload(ctx)
+        } else {
+          const response = await window.fetch(usePayloadPath(to))
+          ctx.$payload = await response.json()
+        }
       } catch (error) {
         ctx.$errors.getPayload = error
       }


### PR DESCRIPTION
When you import the routes on the server, the `getPayload` is an actual function on the component file, so if it exists - we should run it.
on the frontend, you ignored this function at the route object inside the hydration renderer and replaced it with `hasPyaload`.